### PR TITLE
fixes: setup a TCP server health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ build-k8sapi:
 build-all:
 	$(MAKE) build
 	$(MAKE) build-k8sapi
+
+deploy-stack-aws-nlb:
+	cd hack/deploy-stack && . .venv/bin/activate && cdk deploy -f

--- a/hack/deploy-stack/app.py
+++ b/hack/deploy-stack/app.py
@@ -167,6 +167,24 @@ class LabAppStack(cdk.Stack):
         )
         cdk.Tags.of(tg_http).add("Name", "app-svc-tcp-hc-http")
 
+        tg_tcp = elbv2.NetworkTargetGroup(self, "app-svc-tcp-hc-tcp",
+            port=6443, protocol=elbv2.Protocol.TCP,
+            targets=[
+                elbv2.IpTarget(ec2_server01.instance_private_ip, port=6443),
+                elbv2.IpTarget(ec2_server02.instance_private_ip, port=6443)
+            ],
+            health_check=elbv2.HealthCheck(
+                healthy_threshold_count=2,
+                interval=cdk.Duration.seconds(10),
+                port="6444",
+                protocol=elbv2.Protocol.TCP,
+                unhealthy_threshold_count=2,
+            ),
+            target_type=elbv2.TargetType.IP,
+            vpc=vpc,
+        )
+        cdk.Tags.of(tg_tcp).add("Name", "app-svc-tcp-hc-tcp")
+
         # create the default listener. ToDo fix it to support tg that is failing in register_listener()
         listener = lb.add_listener("Listener", port=6443)
         listener.add_targets("Target", port=6443, targets=[])

--- a/internal/server/listener.go
+++ b/internal/server/listener.go
@@ -196,10 +196,11 @@ func NewListener(op *ListenerOptions) (*Listener, error) {
 func (l *Listener) Start() error {
 	l.Event.Send("runtime", "listener", "Starting services...")
 
-	// Start HC Controller
+	// Start Health Check Controller
 	go l.controllerHC.Start()
 
-	// Start HC server
+	// Start Health Check server
+	go l.serverHC.StartController()
 	go l.serverHC.Start()
 
 	// Start Service server

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ const (
 
 type Server interface {
 	Start()
+	StartController()
 	//ShutdownHealthy() error
 	//GetType() string
 	//GetState() bool

--- a/internal/server/server_http.go
+++ b/internal/server/server_http.go
@@ -49,7 +49,7 @@ func NewHTTPServer(cfg *ServerConfig) (*ServerHTTP, error) {
 	})
 
 	srv.listener.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		respBody := fmt.Sprintf("Available routes: \n/healthy\n/ping")
+		respBody := fmt.Sprintf("Available routes: \n/ping\n/%s", cfg.hcPath)
 		w.Header().Set("Content-Type", "text/plain")
 
 		go func() {

--- a/internal/server/server_http.go
+++ b/internal/server/server_http.go
@@ -73,7 +73,7 @@ func NewHTTPServer(cfg *ServerConfig) (*ServerHTTP, error) {
 		}
 		srv.listener.HandleFunc(cfg.hcPath, func(w http.ResponseWriter, r *http.Request) {
 			code := 200
-			respBody := fmt.Sprintf("%s", srv.config.hc.GetHealthyStr())
+			respBody := srv.config.hc.GetHealthyStr()
 			w.Header().Set("Content-Type", "text/plain")
 			if !srv.config.hc.GetHealthy() {
 				code = 500
@@ -89,13 +89,6 @@ func NewHTTPServer(cfg *ServerConfig) (*ServerHTTP, error) {
 					Code: code,
 				}
 				data, _ := json.Marshal(req)
-				// event := `{
-				// 	"response": {
-				// 		"body": respBody,
-				// 		"code": code
-				// 	},
-				// 	"request": r
-				// }`
 				if srv.config.debug {
 					srv.config.event.Send("request", srv.config.name, string(data))
 				}
@@ -126,4 +119,8 @@ func (srv *ServerHTTP) Start() {
 		)
 	}
 	log.Fatal(http.ListenAndServe(port, srv.listener))
+}
+
+// StartController will do nothing in HTTP/S servers (only TCP).
+func (srv *ServerHTTP) StartController() {
 }

--- a/internal/server/server_tcp.go
+++ b/internal/server/server_tcp.go
@@ -2,15 +2,24 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 type ServerTCP struct {
 	listener net.Listener
+	lnConfig *net.ListenConfig
 	config   *ServerConfig
+	quit     chan interface{}
 }
 
 func NewTCPServer(cfg *ServerConfig) (*ServerTCP, error) {
@@ -26,13 +35,18 @@ func NewTCPServer(cfg *ServerConfig) (*ServerTCP, error) {
 	return &srv, nil
 }
 
+// Start is responsible to setup the TCP server, listen,
+// and accept new connections routing the connections to
+// the handler with non-blocking allowing parallel connections.
 func (srv *ServerTCP) Start() {
 	protoName := "TCP"
-
+	srv.lnConfig = &net.ListenConfig{
+		Control:   TCPControl,
+		KeepAlive: -1,
+	}
 	if srv.config.proto == ProtoTLS {
 		protoName = "TLS"
-		msg := fmt.Sprintf("Creating %s server on port %d\n", protoName, srv.config.port)
-		srv.config.event.Send("runtime", srv.config.name, msg)
+		srv.sendEvent(fmt.Sprintf("Creating %s server on port %d\n", protoName, srv.config.port))
 
 		cer, err := tls.LoadX509KeyPair(
 			srv.config.certPem, srv.config.certKey,
@@ -41,7 +55,9 @@ func (srv *ServerTCP) Start() {
 			log.Fatal(err)
 		}
 
-		tlsConfig := &tls.Config{Certificates: []tls.Certificate{cer}}
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{cer},
+		}
 		portStr := fmt.Sprintf(":%d", srv.config.port)
 
 		ln, err := tls.Listen("tcp", portStr, tlsConfig)
@@ -52,11 +68,10 @@ func (srv *ServerTCP) Start() {
 		srv.listener = ln
 
 	} else {
-		msg := fmt.Sprintf("Creating %s server on port %d\n", protoName, srv.config.port)
-		srv.config.event.Send("runtime", srv.config.name, msg)
+		srv.sendEvent(fmt.Sprintf("Creating %s server on port %d\n", protoName, srv.config.port))
 
 		portStr := fmt.Sprintf(":%d", srv.config.port)
-		ln, err := net.Listen("tcp", portStr)
+		ln, err := srv.lnConfig.Listen(context.Background(), "tcp", portStr)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -64,41 +79,160 @@ func (srv *ServerTCP) Start() {
 		srv.listener = ln
 	}
 
-	msg := fmt.Sprintf("Starting %s server on port %d\n", protoName, srv.config.port)
-	srv.config.event.Send("runtime", srv.config.name, msg)
+	srv.sendEvent(fmt.Sprintf("Starting %s server on port %d\n", protoName, srv.config.port))
+	srv.quit = make(chan interface{})
 	for {
 		conn, err := srv.listener.Accept()
 		if err != nil {
-			log.Println(err)
+			select {
+			case <-srv.quit:
+				srv.sendEvent("TCP Server detected Unhealthy state: stopping TCP Listener\n")
+				return
+			default:
+				log.Println("TCP server: Accept error: ", err)
+			}
 			continue
 		}
-		fmt.Println("Accepted...calling handler...")
-		go srv.connHandler(conn)
+
+		// Avoid to call connection handler when HC start to fail
+		if !srv.config.hc.GetHealthy() {
+			continue
+		}
+		go func() {
+			if srv.config.debug {
+				srv.sendEvent("TCP Connection accepted, calling handler.")
+			}
+			srv.connHandler(conn)
+		}()
 	}
+}
+
+func (srv *ServerTCP) Stop() {
+	srv.listener.Close()
 }
 
 func (srv *ServerTCP) connHandler(conn net.Conn) {
 	defer conn.Close()
-	r := bufio.NewReader(conn)
 	for {
-		msg, err := r.ReadString('\n')
+		netMsg, err := bufio.NewReader(conn).ReadString('\n')
 		if err != nil {
-			log.Println(err)
+			// log.Printf("Error ReadString: [%v]", err)
+			switch err {
+			case io.EOF:
+				return
+			default:
+				log.Printf("Error ReadString: [%v]", err)
+			}
 			return
 		}
 
-		srv.config.event.Send("request", srv.config.name, msg)
+		srv.config.event.Send("request", srv.config.name, netMsg)
 		if srv.config.hcServer {
 			srv.config.metric.Inc("requests_hc")
 		} else {
 			srv.config.metric.Inc("requests_service")
 		}
 
-		healthy := fmt.Sprintf("%s\n", srv.config.hc.GetHealthyStr())
-		n, err := conn.Write([]byte(healthy))
+		cmd := strings.TrimSpace(string(netMsg))
+		if cmd == "STOP" {
+			break
+		}
+
+		n, err := conn.Write([]byte(string(srv.config.hc.GetHealthyStr())))
 		if err != nil {
-			log.Println(n, err)
-			return
+			log.Println("Error writing response: ", n, err)
+		}
+		if srv.config.debug {
+			log.Printf("received from %v: [%s]", conn.RemoteAddr(), cmd)
 		}
 	}
+}
+
+// StartController is a infinity loop to watch the Health Check
+// Controller and force the server to not answer TCP requests when
+// the health check should be in failing state.
+func (srv *ServerTCP) StartController() {
+	waitReconcile := time.Duration(1 * time.Second)
+	waitStateTransiction := time.Duration(5 * time.Second)
+
+	srv.sendEvent("TCP Server controller: starting in 5 seconds.")
+	srv.ControllerWaiter(waitStateTransiction)
+	for {
+		// Use the controller only in health check servers
+		if !(srv.config.hcServer) {
+			fmt.Println("Ignoring Server Controller, it is enabled only in Health check servers.")
+			return
+		}
+
+		log.Println(srv.config.hc.GetHealthy(), srv.ServerPortIsOpen())
+		// State> health check is failing and server is up.
+		// Action: Server needs to be stopped
+		if !(srv.config.hc.GetHealthy()) && (srv.ServerPortIsOpen()) {
+			srv.sendEvent("TCP Server controller: unhealthy state detected, closing the TCP listener and waiting for transiction...")
+			close(srv.quit)
+			srv.Stop()
+			srv.ControllerWaiter(waitStateTransiction)
+			continue
+		}
+
+		// State> health check has cleaned and server is down.
+		// Action: Server needs to be started
+		if (srv.config.hc.GetHealthy()) && !(srv.ServerPortIsOpen()) {
+			srv.sendEvent("TCP Server controller: healthy state detected, starting TCP listener server...")
+			go srv.Start()
+			srv.ControllerWaiter(waitStateTransiction)
+			continue
+		}
+
+		// State> Normal operation
+		// Health check is success and server.
+		if !(srv.config.hc.GetHealthy()) && !(srv.ServerPortIsOpen()) {
+			srv.sendEvent("TCP Server controller: health check is failing and server is stopped, waiting to state change")
+		}
+
+		// Last state> Health check failing and server is down.
+		// Action: Wait to the next cycle to check the HC state.
+		srv.ControllerWaiter(waitReconcile)
+	}
+}
+
+// ControllerWaiter wait in seconds
+func (srv *ServerTCP) ControllerWaiter(t time.Duration) {
+	time.Sleep(t)
+}
+
+// ServerPortIsOpen checks whether the TCP port is Opened, and return
+// a boolean. True when the TCP Port is opened.
+func (srv *ServerTCP) ServerPortIsOpen() bool {
+	isOpen := true
+	_, err := net.Dial("tcp", fmt.Sprintf(":%d", srv.config.port))
+	if err != nil {
+		isOpen = false
+	}
+	return isOpen
+}
+
+// TCPControl set of flags of TCP listener to reuse the
+// socket when the service needs to be restored.
+// This function will work only for unix systems. To port it
+// to other systems, we advise to use the external lib go-reuseport.
+// https://github.com/libp2p/go-reuseport/blob/master/control_unix.go
+func TCPControl(network, address string, c syscall.RawConn) error {
+	var err error
+	c.Control(func(fd uintptr) {
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if err != nil {
+			return
+		}
+
+		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		if err != nil {
+			return
+		}
+	})
+	return err
+}
+
+func (srv *ServerTCP) sendEvent(msg string) {
+	srv.config.event.Send("runtime", srv.config.name, msg)
 }

--- a/internal/server/server_tcp.go
+++ b/internal/server/server_tcp.go
@@ -164,7 +164,6 @@ func (srv *ServerTCP) StartController() {
 			return
 		}
 
-		log.Println(srv.config.hc.GetHealthy(), srv.ServerPortIsOpen())
 		// State> health check is failing and server is up.
 		// Action: Server needs to be stopped
 		if !(srv.config.hc.GetHealthy()) && (srv.ServerPortIsOpen()) {
@@ -184,14 +183,14 @@ func (srv *ServerTCP) StartController() {
 			continue
 		}
 
-		// State> Normal operation
-		// Health check is success and server.
+		// State> Health check failing and server is down.
+		// Action: register the event and wait to to reconcile period
 		if !(srv.config.hc.GetHealthy()) && !(srv.ServerPortIsOpen()) {
 			srv.sendEvent("TCP Server controller: health check is failing and server is stopped, waiting to state change")
 		}
 
-		// Last state> Health check failing and server is down.
-		// Action: Wait to the next cycle to check the HC state.
+		// Last state> Health check and server listening successfully.
+		// Action: wait to to reconcile period.
 		srv.ControllerWaiter(waitReconcile)
 	}
 }


### PR DESCRIPTION
Fix the TCP server that was not well tested. In this version, the TCP health check server is integrated with the termination engine, which means that the health check server running in TCP socket will close the socket when the health check is in termination state (failure mode) and will re-open the port when the termination timeout finishes.